### PR TITLE
Issue#41

### DIFF
--- a/src/components/Button/NotCompliedProgressButton.jsx
+++ b/src/components/Button/NotCompliedProgressButton.jsx
@@ -4,7 +4,7 @@ import Typography from "@mui/material/Typography";
 import { css } from "@emotion/react";
 
 const NotCompliedProgressButton = ({ onClick, progress = -100 }) => {
-    const button = { label: "未実施", value: 100 };
+    const button = { label: "未実施", value: 99.9 };
 
     return (
         <>

--- a/src/components/Button/ReverseListButton.jsx
+++ b/src/components/Button/ReverseListButton.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { css } from "@emotion/react";
+
+import { Button, Tooltip } from "@mui/material";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
+
+const ReverseListButton = ({ isAsc, setIsAsc }) => {
+    const handleClick = () => {
+        setIsAsc(!isAsc);
+    };
+
+    return (
+        <Tooltip title="昇順・降順を入れ替える" placement="right">
+            <Button onClick={handleClick} css={styles.button}>
+                <SwapVertIcon />
+            </Button>
+        </Tooltip>
+    );
+};
+
+const styles = {
+    button: css`
+        padding: 0;
+    `,
+};
+
+export default ReverseListButton;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -31,7 +31,6 @@ const Header = ({ title }) => {
                     {user && (
                         <div css={styles.buttonContainer}>
                             <ProfileDialog />
-                            <UsageDialog />
 
                             <Button css={styles.button} onClick={logout}>
                                 ログアウト

--- a/src/components/Header/components/UsageDialog.jsx
+++ b/src/components/Header/components/UsageDialog.jsx
@@ -1,33 +1,33 @@
-import Dialog from "@mui/material/Dialog";
-import DialogActions from "@mui/material/DialogActions";
-import DialogContent from "@mui/material/DialogContent";
-import DialogTitle from "@mui/material/DialogTitle";
-import UsageButton from "../../Button/UsageButton";
-import BackButton from "../../Button/BackButton";
+// import Dialog from "@mui/material/Dialog";
+// import DialogActions from "@mui/material/DialogActions";
+// import DialogContent from "@mui/material/DialogContent";
+// import DialogTitle from "@mui/material/DialogTitle";
+// import UsageButton from "../../Button/UsageButton";
+// import BackButton from "../../Button/BackButton";
 
-import useDialog from "hooks/useDialog";
+// import useDialog from "hooks/useDialog";
 
-const UsageDialog = () => {
-    const { open, handleOpen, handleClose } = useDialog(false);
-    return (
-        <>
-            <UsageButton onClick={handleOpen} />
+// const UsageDialog = () => {
+//     const { open, handleOpen, handleClose } = useDialog(false);
+//     return (
+//         <>
+//             <UsageButton onClick={handleOpen} />
 
-            <Dialog open={open} onClose={handleClose}>
-                <DialogTitle>使い方</DialogTitle>
+//             <Dialog open={open} onClose={handleClose}>
+//                 <DialogTitle>使い方</DialogTitle>
 
-                <DialogContent
-                    style={{ display: "flex", whiteSpace: "pre-line" }}
-                >
-                    <div style={{ width: "40vw" }}>制作中</div>
-                </DialogContent>
+//                 <DialogContent
+//                     style={{ display: "flex", whiteSpace: "pre-line" }}
+//                 >
+//                     <div style={{ width: "40vw" }}>制作中</div>
+//                 </DialogContent>
 
-                <DialogActions>
-                    <BackButton onClick={handleClose} />
-                </DialogActions>
-            </Dialog>
-        </>
-    );
-};
+//                 <DialogActions>
+//                     <BackButton onClick={handleClose} />
+//                 </DialogActions>
+//             </Dialog>
+//         </>
+//     );
+// };
 
-export default UsageDialog;
+// export default UsageDialog;

--- a/src/features/DitailDialog/components/SideMap.jsx
+++ b/src/features/DitailDialog/components/SideMap.jsx
@@ -50,8 +50,8 @@ const SideMap = ({ mapData }) => {
                         //進捗度に応じて、ピンの色を変更
                         mapData.progress === 100
                             ? CompleteIcon
-                            : // 進捗度が0であることは現状ないため、一旦null?の反転で実装
-                            !mapData.progress && beforeOneMonth < now
+                            : mapData.progress === 0 &&
+                              beforeOneMonth > new Date(mapData.timestamp)
                             ? alertIcon
                             : IncompleteIcon
                     }

--- a/src/features/DitailDialog/components/SideMap.jsx
+++ b/src/features/DitailDialog/components/SideMap.jsx
@@ -5,6 +5,7 @@ import "leaflet/dist/leaflet.css";
 import { css } from "@emotion/react";
 import { Button } from "@mui/material";
 import GoogleIcon from "@mui/icons-material/Google";
+import MovedButton from "features/DitailDialog/components/SideMap/MovedButton";
 
 let IncompleteIcon = Leaflet.icon({
     iconUrl:
@@ -22,7 +23,7 @@ let alertIcon = Leaflet.icon({
 const SideMap = ({ mapData }) => {
     const googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${mapData.latitude},${mapData.longitude}`;
 
-    const date = Date.parse(mapData.timestamp);
+    const date = new Date(mapData.timestamp);
     const now = new Date();
     const beforeOneMonth = new Date(
         now.getFullYear(),
@@ -50,8 +51,7 @@ const SideMap = ({ mapData }) => {
                         //進捗度に応じて、ピンの色を変更
                         mapData.progress === 100
                             ? CompleteIcon
-                            : mapData.progress === 0 &&
-                              beforeOneMonth > new Date(mapData.timestamp)
+                            : mapData.progress === 0 && beforeOneMonth > date
                             ? alertIcon
                             : IncompleteIcon
                     }
@@ -63,15 +63,20 @@ const SideMap = ({ mapData }) => {
                     </Tooltip>
                 </Marker>
             </MapContainer>
-            <Button
-                href={googleMapUrl}
-                target="_blank"
-                variant="outlined"
-                css={styles.googleMapButton}
-                startIcon={<GoogleIcon />}
-            >
-                GoogleMapで確認
-            </Button>
+            <div css={styles.buttonsContainer}>
+                <Button
+                    href={googleMapUrl}
+                    target="_blank"
+                    variant="contained"
+                    css={styles.googleMapButton}
+                    startIcon={<GoogleIcon />}
+                >
+                    GoogleMapで確認
+                </Button>
+                <MovedButton
+                    mapData={mapData}
+                />
+            </div>
         </div>
     );
 };
@@ -86,13 +91,20 @@ const styles = {
         width: 40vw;
     `,
     googleMapButton: css`
-        color: black;
+        color: white;
         text-transform: none;
-        margin: 5px;
+        margin: 5px 0 5px 5px;
+        font-size: 15px;
+        width: 92%;
     `,
     tooltipContainer: css`
         font-size: 15px;
     `,
+    buttonsContainer: css`
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+    `
 };
 
 export default SideMap;

--- a/src/features/DitailDialog/components/SideMap.jsx
+++ b/src/features/DitailDialog/components/SideMap.jsx
@@ -49,7 +49,7 @@ const SideMap = ({ mapData }) => {
                     position={[mapData.latitude, mapData.longitude]}
                     icon={
                         //進捗度に応じて、ピンの色を変更
-                        mapData.progress === 100
+                        mapData.progress === 99.9 || mapData.progress === 100
                             ? CompleteIcon
                             : mapData.progress === 0 && beforeOneMonth > date
                             ? alertIcon
@@ -73,9 +73,7 @@ const SideMap = ({ mapData }) => {
                 >
                     GoogleMapで確認
                 </Button>
-                <MovedButton
-                    mapData={mapData}
-                />
+                <MovedButton mapData={mapData} />
             </div>
         </div>
     );
@@ -104,7 +102,7 @@ const styles = {
         display: flex;
         justify-content: space-between;
         width: 100%;
-    `
+    `,
 };
 
 export default SideMap;

--- a/src/features/DitailDialog/components/SideMap/MoveDialog.jsx
+++ b/src/features/DitailDialog/components/SideMap/MoveDialog.jsx
@@ -60,7 +60,6 @@ const MoveDialog = ({ mapData, moved, setMoved }) => {
     };
 
     const handleClick = () => {
-
         post({
             id: mapData.id,
             latitude: markerPosition.lat,
@@ -113,6 +112,7 @@ const MoveDialog = ({ mapData, moved, setMoved }) => {
                         position={markerPosition}
                         icon={
                             //進捗度に応じて、ピンの色を変更
+                            mapData.progress === 99.9 ||
                             mapData.progress === 100
                                 ? CompleteIcon
                                 : mapData.progress === 0 &&

--- a/src/features/DitailDialog/components/SideMap/MoveDialog.jsx
+++ b/src/features/DitailDialog/components/SideMap/MoveDialog.jsx
@@ -31,7 +31,7 @@ let baseIcon = Leaflet.icon({
 
 const MoveDialog = ({ mapData, moved, setMoved }) => {
     const markerRef = useRef(null);
-    const { postData } = usePostGAS();
+    const { post } = usePostGAS();
 
     const date = new Date(mapData.timestamp);
     const now = new Date();
@@ -60,11 +60,13 @@ const MoveDialog = ({ mapData, moved, setMoved }) => {
     };
 
     const handleClick = () => {
-        postData({
+
+        post({
             id: mapData.id,
             latitude: markerPosition.lat,
             longitude: markerPosition.lng,
         });
+
         setMoved(false);
         window.location.reload();
     };

--- a/src/features/DitailDialog/components/SideMap/MoveDialog.jsx
+++ b/src/features/DitailDialog/components/SideMap/MoveDialog.jsx
@@ -1,0 +1,171 @@
+import React, { useState, useRef } from "react";
+
+import { css } from "@emotion/react";
+
+import Leaflet from "leaflet";
+import { Tooltip, MapContainer, TileLayer, Marker } from "react-leaflet";
+
+import { Dialog, Button, DialogTitle } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+
+import useDialog from "hooks/useDialog";
+import usePostGAS from "hooks/usePostGAS";
+
+let IncompleteIcon = Leaflet.icon({
+    iconUrl:
+        "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-blue.png",
+});
+let CompleteIcon = Leaflet.icon({
+    iconUrl:
+        "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-grey.png",
+});
+let alertIcon = Leaflet.icon({
+    iconUrl:
+        "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
+});
+
+let baseIcon = Leaflet.icon({
+    iconUrl:
+        "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-black.png",
+});
+
+const MoveDialog = ({ mapData, moved, setMoved }) => {
+    const markerRef = useRef(null);
+    const { postData } = usePostGAS();
+
+    const date = new Date(mapData.timestamp);
+    const now = new Date();
+    const beforeOneMonth = new Date(
+        now.getFullYear(),
+        now.getMonth() - 1,
+        now.getDate()
+    );
+
+    const { open, _, handleClose } = useDialog(moved);
+
+    const [markerPosition, setMarkerPosition] = useState(
+        Leaflet.latLng([mapData.latitude, mapData.longitude])
+    );
+
+    const eventHandlers = {
+        dragstart: () => {
+            const marker = markerRef.current;
+            marker.setOpacity(0.4);
+        },
+        dragend: () => {
+            const marker = markerRef.current;
+            marker.setOpacity(1);
+            setMarkerPosition(marker.getLatLng());
+        },
+    };
+
+    const handleClick = () => {
+        postData({
+            id: mapData.id,
+            latitude: markerPosition.lat,
+            longitude: markerPosition.lng,
+        });
+        setMoved(false);
+        window.location.reload();
+    };
+
+    const handleCancel = () => {
+        handleClose();
+        setMoved(false);
+    };
+
+    return (
+        <>
+            <Dialog open={open} fullWidth maxWidth="xl">
+                <Button onClick={handleCancel} css={styles.closeButton}>
+                    <CloseIcon />
+                </Button>
+
+                <DialogTitle css={styles.title}>
+                    <span css={styles.titleText}>
+                        変更したい位置に移動させてください
+                    </span>
+                </DialogTitle>
+
+                <MapContainer
+                    center={[mapData.latitude, mapData.longitude]}
+                    zoom={14}
+                    scrollWheelZoom
+                    zoomControl={false}
+                    centerUpdate
+                    css={styles.mapContainer}
+                >
+                    <TileLayer
+                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    />
+                    <Marker
+                        position={[mapData.latitude, mapData.longitude]}
+                        icon={baseIcon}
+                    >
+                        <Tooltip direction="top" permanent>
+                            変更前
+                        </Tooltip>
+                    </Marker>
+                    <Marker
+                        position={markerPosition}
+                        icon={
+                            //進捗度に応じて、ピンの色を変更
+                            mapData.progress === 100
+                                ? CompleteIcon
+                                : mapData.progress === 0 &&
+                                  beforeOneMonth > date
+                                ? alertIcon
+                                : IncompleteIcon
+                        }
+                        ref={markerRef}
+                        draggable="true"
+                        eventHandlers={eventHandlers}
+                    >
+                        <Tooltip direction="top" permanent>
+                            <div
+                            // css={styles.tooltipContainer}
+                            >
+                                緯度:{markerPosition.lat}
+                                <br />
+                                経度:{markerPosition.lng}
+                            </div>
+                        </Tooltip>
+                    </Marker>
+                </MapContainer>
+                <Button
+                    variant="contained"
+                    onClick={handleClick}
+                    css={styles.button}
+                >
+                    決定
+                </Button>
+            </Dialog>
+        </>
+    );
+};
+
+const styles = {
+    title: css`
+        text-align: center;
+        padding: 0;
+    `,
+    titleText: css`
+        font-size: 35px;
+        font-weight: bold;
+    `,
+    mapContainer: css`
+        width: 90%;
+        height: 70vh;
+        margin: 0 auto;
+    `,
+    button: css`
+        margin: 1vh auto;
+        width: 30%;
+    `,
+    closeButton: css`
+        margin: 0 0 0 auto;
+    `,
+};
+
+export default MoveDialog;

--- a/src/features/DitailDialog/components/SideMap/MovedButton.jsx
+++ b/src/features/DitailDialog/components/SideMap/MovedButton.jsx
@@ -1,0 +1,128 @@
+import React, { useContext, useState } from "react";
+
+
+
+import { css } from "@emotion/react";
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogTitle,
+    Typography,
+    Divider,
+    Tooltip,
+} from "@mui/material";
+import EditLocationIcon from "@mui/icons-material/EditLocation";
+import WarningIcon from "@mui/icons-material/Warning";
+
+import useDialog from "hooks/useDialog";
+import MoveDialog from "./MoveDialog";
+
+const MovedButton = ({ mapData }) => {
+    const { open, handleOpen, handleClose } = useDialog(false);
+
+    const [moved, setMoved] = useState(false);
+
+    const handleChange = () => {
+        handleClose();
+        setMoved(true);
+    };
+
+    // const handleLock = () => {
+    //     setMoved(false);
+    //     setMarkerPosition(newMarkerPosition);
+
+    //     postData({
+    //         id: mapDataId,
+    //         latitude: newMarkerPosition.lat,
+    //         longitude: newMarkerPosition.lng,
+    //     });
+
+    //     // 妥協案:HomeのMapのピンにも変更を反映させるためにページをリロードする処理
+    //     window.location.reload();
+
+    //     // mapData[mapData.id]でそこの緯度経度を上書きする方法でやってみた
+    //     // -> 非常に複雑だし、未完了・完了」・全件表示でそれぞれの場合に応じたmapData,archivedMapData, allMapDataを変更して、SaveDisplayMapIconsに渡すようにしなきゃいけない。。。
+
+    //     // const newMapData = mapData.map((data) => {
+    //     //     if (data.id === mapDataId) {
+    //     //         const { latitude, longitude, ...rest } = data;
+    //     //         return {
+    //     //             ...rest,
+    //     //             latitude: newMarkerPosition.lat,
+    //     //             longitude: newMarkerPosition.lng,
+    //     //         };
+    //     //     } else {
+    //     //         return data;
+    //     //     }
+    //     // });
+
+    //     // console.log(newMapData);
+    //     // setMapData(newMapData);
+    //     // saveDisplayIcons(hogehoge)
+
+    // };
+
+    return (
+        <>
+            {moved ? (
+                <MoveDialog mapData={mapData} moved={moved} setMoved={setMoved}/>
+            ) : (
+                <>
+                    <Tooltip title="ピンの位置を変更する" placement="bottom">
+                        <Button
+                            variant="outlined"
+                            css={styles.button}
+                            onClick={handleOpen}
+                        >
+                            <EditLocationIcon />
+                        </Button>
+                    </Tooltip>
+                    <Dialog open={open} maxWidth="xs" fullWidth>
+                        <DialogTitle>本当にピンを移動しますか</DialogTitle>
+                        <Divider />
+                        <div css={styles.contentContainer}>
+                            <Typography>
+                                マップ上のピンの位置を変更できるようにします
+                            </Typography>
+                            <div css={styles.alertContainer}>
+                                <WarningIcon css={styles.alertIcon} />
+                                <span css={styles.text}>
+                                    後から変更を取り消すことはできません
+                                </span>
+                            </div>
+                        </div>
+                        <DialogActions>
+                            <Button onClick={handleChange}>はい</Button>
+                            <Button onClick={handleClose}>いいえ</Button>
+                        </DialogActions>
+                    </Dialog>
+                </>
+            )}
+        </>
+    );
+};
+
+const styles = {
+    contentContainer: css`
+        margin: 5%;
+        width: 100%;
+    `,
+    alertContainer: css`
+        margin-top: 2%;
+        vertical-align: middle;
+        display: inline-flex;
+        width: 100%;
+    `,
+    button: css`
+        color: black;
+        text-transform: none;
+        margin: 5px;
+        font-size: 15px;
+    `,
+    text: css`
+        margin-left: 2%;
+    `,
+};
+
+export default MovedButton;

--- a/src/features/Map/components/MapMarker.jsx
+++ b/src/features/Map/components/MapMarker.jsx
@@ -25,6 +25,7 @@ let alertIcon = Leaflet.icon({
 const MapMaker = ({ mapData, saveProgress, dbMessages }) => {
     const googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${mapData.latitude},${mapData.longitude}`;
 
+    const date = new Date(mapData.timestamp);
     const now = new Date();
     const beforeOneMonth = new Date(
         now.getFullYear(),
@@ -41,7 +42,7 @@ const MapMaker = ({ mapData, saveProgress, dbMessages }) => {
                 mapData.progress === 100
                     ? CompleteIcon
                     : mapData.progress === 0 &&
-                      beforeOneMonth > new Date(mapData.timestamp)
+                      beforeOneMonth > date
                     ? alertIcon
                     : IncompleteIcon
             }

--- a/src/features/Map/components/MapMarker.jsx
+++ b/src/features/Map/components/MapMarker.jsx
@@ -41,8 +41,7 @@ const MapMaker = ({ mapData, saveProgress, dbMessages }) => {
                 //進捗度に応じて、ピンの色を変更
                 mapData.progress === 100
                     ? CompleteIcon
-                    : mapData.progress === 0 &&
-                      beforeOneMonth > date
+                    : mapData.progress === 0 && beforeOneMonth > date
                     ? alertIcon
                     : IncompleteIcon
             }
@@ -75,14 +74,14 @@ const MapMaker = ({ mapData, saveProgress, dbMessages }) => {
                             GoogleMapで確認
                         </Button>
                     </div>
+                    <DitailDialog
+                        mapData={mapData}
+                        saveProgress={saveProgress}
+                        dbMessages={dbMessages}
+                        listLabel="詳細確認"
+                        variant="outlined"
+                    />
                 </div>
-                <DitailDialog
-                    mapData={mapData}
-                    saveProgress={saveProgress}
-                    dbMessages={dbMessages}
-                    listLabel="詳細確認"
-                    variant="outlined"
-                />
             </Popup>
         </Marker>
     );
@@ -91,9 +90,9 @@ const MapMaker = ({ mapData, saveProgress, dbMessages }) => {
 const styles = {
     popupContainer: css`
         white-space: nowrap;
-        min-width: 200px;
-        max-width: 300px;
-        height: 110px;
+        min-width: 10vw;
+        max-width: 20vw;
+        height: 15vh;
         font-size: 15px;
     `,
     googleMapButton: css`

--- a/src/features/Map/components/MapMarker.jsx
+++ b/src/features/Map/components/MapMarker.jsx
@@ -40,8 +40,8 @@ const MapMaker = ({ mapData, saveProgress, dbMessages }) => {
                 //進捗度に応じて、ピンの色を変更
                 mapData.progress === 100
                     ? CompleteIcon
-                    : // 進捗度が0であることは現状ないため、一旦null?の反転で実装
-                    !mapData.progress && beforeOneMonth < now
+                    : mapData.progress === 0 &&
+                      beforeOneMonth > new Date(mapData.timestamp)
                     ? alertIcon
                     : IncompleteIcon
             }

--- a/src/features/Map/components/MapMarker.jsx
+++ b/src/features/Map/components/MapMarker.jsx
@@ -39,7 +39,7 @@ const MapMaker = ({ mapData, saveProgress, dbMessages }) => {
             css={styles.leaflet}
             icon={
                 //進捗度に応じて、ピンの色を変更
-                mapData.progress === 100
+                mapData.progress === 99.9 || mapData.progress === 100
                     ? CompleteIcon
                     : mapData.progress === 0 && beforeOneMonth > date
                     ? alertIcon

--- a/src/features/SideMenu/SideMenu.jsx
+++ b/src/features/SideMenu/SideMenu.jsx
@@ -2,7 +2,6 @@ import CloseButton from "components/Button/CloseButton";
 import OpenButton from "components/Button/OpenButton";
 import { useState } from "react";
 import MenuBar from "./components/MenuBar";
-import SearchMenu from "./components/SearchMenu/SearchMenu";
 import Incomplete from "./components/Incomplete";
 import Complete from "./components/Complete";
 import All from "./components/All";
@@ -38,8 +37,6 @@ const SideMenu = ({
             archivedMapIcon();
         } else if (i === 2) {
             allMapIcon();
-        } else if (i === 3) {
-            //
         }
         setMenu(i);
     };
@@ -79,14 +76,6 @@ const SideMenu = ({
                             allMapData={allData}
                             dbMessages={dbMessages}
                             saveDisplayMapIcons={saveDisplayMapIcons}
-                        />
-                    )}
-
-                    {menu === 3 && (
-                        <SearchMenu
-                            mapData={allData}
-                            saveDisplayMapIcons={saveDisplayMapIcons}
-                            dbMessages={dbMessages}
                         />
                     )}
                 </div>

--- a/src/features/SideMenu/SideMenu.jsx
+++ b/src/features/SideMenu/SideMenu.jsx
@@ -61,16 +61,25 @@ const SideMenu = ({
                     <MenuBar menu={menu} selectMenu={selectMenu} />
 
                     {menu === 0 && (
-                        <Incomplete mapData={mapData} dbMessages={dbMessages} />
+                        <Incomplete
+                            mapData={mapData}
+                            dbMessages={dbMessages}
+                            saveDisplayMapIcons={saveDisplayMapIcons}
+                        />
                     )}
                     {menu === 1 && (
                         <Complete
                             archivedMapData={archivedMapData}
                             dbMessages={dbMessages}
+                            saveDisplayMapIcons={saveDisplayMapIcons}
                         />
                     )}
                     {menu === 2 && (
-                        <All allMapData={allData} dbMessages={dbMessages} />
+                        <All
+                            allMapData={allData}
+                            dbMessages={dbMessages}
+                            saveDisplayMapIcons={saveDisplayMapIcons}
+                        />
                     )}
 
                     {menu === 3 && (

--- a/src/features/SideMenu/TitleRow.jsx
+++ b/src/features/SideMenu/TitleRow.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import { css } from "@emotion/react";
+
+const TitleRow = () => {
+    return (
+        <div css={styles.container}>
+            <div css={styles.box}>
+                <span>苦情番号</span>
+                <span>苦情箇所の名称</span>
+                <span>情報提供者</span>
+            </div>
+        </div>
+    );
+};
+
+const styles = {
+  container: css`
+    border-bottom: 1px solid #cecece;
+  `,
+    box: css`
+        margin-top: 10px;
+        display: flex;
+        width: 85%;
+        justify-content: space-between;
+        font-size: 11px;
+    `,
+};
+
+export default TitleRow;

--- a/src/features/SideMenu/TitleRow.jsx
+++ b/src/features/SideMenu/TitleRow.jsx
@@ -1,8 +1,13 @@
 import React from "react";
 
 import { css } from "@emotion/react";
+import { Button, Tooltip } from "@mui/material";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 
-const TitleRow = () => {
+const TitleRow = ({ isAsc, setIsAsc }) => {
+    const handleClick = () => {
+        setIsAsc(!isAsc);
+    };
     return (
         <div css={styles.container}>
             <div css={styles.box}>
@@ -10,14 +15,20 @@ const TitleRow = () => {
                 <span>苦情箇所の名称</span>
                 <span>情報提供者</span>
             </div>
+            <Tooltip title="昇順・降順を入れ替える" placement="right">
+                <Button onClick={handleClick}>
+                    <SwapVertIcon />
+                </Button>
+            </Tooltip>
         </div>
     );
 };
 
 const styles = {
-  container: css`
-    border-bottom: 1px solid #cecece;
-  `,
+    container: css`
+        border-bottom: 1px solid #cecece;
+        display: flex;
+    `,
     box: css`
         margin-top: 10px;
         display: flex;

--- a/src/features/SideMenu/TitleRow.jsx
+++ b/src/features/SideMenu/TitleRow.jsx
@@ -4,32 +4,18 @@ import { css } from "@emotion/react";
 import { Button, Tooltip } from "@mui/material";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 
-const TitleRow = ({ isAsc, setIsAsc }) => {
-    const handleClick = () => {
-        setIsAsc(!isAsc);
-    };
+const TitleRow = () => {
     return (
         <div css={styles.container}>
-            <div css={styles.box}>
-                <span>苦情番号</span>
-                <span>苦情箇所の名称</span>
-                <span>情報提供者</span>
-            </div>
-            <Tooltip title="昇順・降順を入れ替える" placement="right">
-                <Button onClick={handleClick}>
-                    <SwapVertIcon />
-                </Button>
-            </Tooltip>
+            <span>苦情番号</span>
+            <span>苦情箇所の名称</span>
+            <span>情報提供者</span>
         </div>
     );
 };
 
 const styles = {
     container: css`
-        border-bottom: 1px solid #cecece;
-        display: flex;
-    `,
-    box: css`
         margin-top: 10px;
         display: flex;
         width: 85%;

--- a/src/features/SideMenu/components/All.jsx
+++ b/src/features/SideMenu/components/All.jsx
@@ -14,7 +14,7 @@ const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
     const [searchItem, setSearchItem] = useState("respondent_name");
     const [sortItem, setSortItem] = useState("id");
-    const [isAsc, setIsAsc] = useState(false);
+    const [isAsc, setIsAsc] = useState(true);
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(

--- a/src/features/SideMenu/components/All.jsx
+++ b/src/features/SideMenu/components/All.jsx
@@ -5,6 +5,7 @@ import { css } from "@emotion/react";
 import { TextField } from "@mui/material";
 
 import AllList from "./All/AllList";
+import TitleRow from "../TitleRow";
 
 const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
@@ -32,6 +33,7 @@ const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
                 }}
                 css={styles.textField}
             />
+            <TitleRow />
             {allMapData === undefined ? (
                 <div css={styles.message}>データがありません</div>
             ) : allMapData.filter((data) =>

--- a/src/features/SideMenu/components/All.jsx
+++ b/src/features/SideMenu/components/All.jsx
@@ -6,11 +6,18 @@ import { TextField } from "@mui/material";
 
 import AllList from "./All/AllList";
 
-const All = ({ allMapData, dbMessages }) => {
+const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
+
+    const changeMapIcons = (newKeyword) => {
+        saveDisplayMapIcons(
+            allMapData.filter((data) => data.respondent_name.includes(newKeyword))
+        );
+    };
 
     const handleChange = (e) => {
         const newKeyword = e.target.value;
+        changeMapIcons(newKeyword);
         setKeyword(newKeyword);
     };
 

--- a/src/features/SideMenu/components/All.jsx
+++ b/src/features/SideMenu/components/All.jsx
@@ -12,6 +12,8 @@ import SelectSortItem from "./SearchMenu/SelectSortItem";
 const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
     const [searchItem, setSearchItem] = useState("respondent_name");
+    const [sortItem, setSortItem] = useState("id");
+    const [isAsc, setIsAsc] = useState(false);
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(
@@ -39,19 +41,32 @@ const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
                 />
                 <div css={styles.buttons}>
                     <SelectSearchItem setSearchItem={setSearchItem} />
-                    {/* TODO: 並び替え機能 */}
-                    <SelectSortItem />
+                    <SelectSortItem
+                        setSortItem={setSortItem}
+                        isAsc={isAsc}
+                        setIsAsc={setIsAsc}
+                    />
                 </div>
             </div>
-            <TitleRow />
+            <TitleRow isAsc={isAsc} setIsAsc={setIsAsc} />
             {allMapData === undefined ? (
                 <div css={styles.message}>データがありません</div>
             ) : allMapData.filter((data) => data[searchItem].includes(keyword))
                   .length !== 0 ? (
                 <AllList
-                    allMapData={allMapData.filter((data) =>
-                        data[searchItem].includes(keyword)
-                    )}
+                    allMapData={allMapData
+                        .filter((data) => data[searchItem].includes(keyword))
+                        .sort((a, b) =>
+                            sortItem === "scheduled" || "timestamp"
+                                ? isAsc
+                                    ? new Date(a[sortItem]) -
+                                      new Date(b[sortItem])
+                                    : new Date(b[sortItem]) -
+                                      new Date(a[sortItem])
+                                : isAsc
+                                ? a[sortItem] - b[sortItem]
+                                : b[sortItem] - a[sortItem]
+                        )}
                     dbMessages={dbMessages}
                 />
             ) : (

--- a/src/features/SideMenu/components/All.jsx
+++ b/src/features/SideMenu/components/All.jsx
@@ -8,6 +8,7 @@ import AllList from "./All/AllList";
 import TitleRow from "../TitleRow";
 import SelectSearchItem from "./SearchMenu/SelectSearchItem";
 import SelectSortItem from "./SearchMenu/SelectSortItem";
+import ReverseListButton from "components/Button/ReverseListButton";
 
 const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
@@ -48,7 +49,15 @@ const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
                     />
                 </div>
             </div>
-            <TitleRow isAsc={isAsc} setIsAsc={setIsAsc} />
+            <div css={styles.titleRowContainer}>
+                <TitleRow />
+                <ReverseListButton
+                    isAsc={isAsc}
+                    setIsAsc={setIsAsc}
+                    css={styles.reverseListButton}
+                />
+            </div>
+
             {allMapData === undefined ? (
                 <div css={styles.message}>データがありません</div>
             ) : allMapData.filter((data) => data[searchItem].includes(keyword))
@@ -84,6 +93,10 @@ const styles = {
         width: 40%;
         margin-top: 5px;
         margin-right: 2%;
+    `,
+    titleRowContainer: css`
+        display: flex;
+        border-bottom: 1px solid #cecece;
     `,
     textField: css`
         justify-content: left;

--- a/src/features/SideMenu/components/All.jsx
+++ b/src/features/SideMenu/components/All.jsx
@@ -6,13 +6,16 @@ import { TextField } from "@mui/material";
 
 import AllList from "./All/AllList";
 import TitleRow from "../TitleRow";
+import SelectSearchItem from "./SearchMenu/SelectSearchItem";
+import SelectSortItem from "./SearchMenu/SelectSortItem";
 
 const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
+    const [searchItem, setSearchItem] = useState("respondent_name");
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(
-            allMapData.filter((data) => data.respondent_name.includes(newKeyword))
+            allMapData.filter((data) => data[searchItem].includes(newKeyword))
         );
     };
 
@@ -24,24 +27,30 @@ const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
 
     return (
         <>
-            <TextField
-                id="field"
-                variant="outlined"
-                label="検索"
-                onChange={(e) => {
-                    handleChange(e);
-                }}
-                css={styles.textField}
-            />
+            <div css={styles.searchContainer}>
+                <TextField
+                    id="field"
+                    variant="outlined"
+                    label="検索"
+                    onChange={(e) => {
+                        handleChange(e);
+                    }}
+                    css={styles.textField}
+                />
+                <div css={styles.buttons}>
+                    <SelectSearchItem setSearchItem={setSearchItem} />
+                    {/* TODO: 並び替え機能 */}
+                    <SelectSortItem />
+                </div>
+            </div>
             <TitleRow />
             {allMapData === undefined ? (
                 <div css={styles.message}>データがありません</div>
-            ) : allMapData.filter((data) =>
-                  data.respondent_name.includes(keyword)
-              ).length !== 0 ? (
+            ) : allMapData.filter((data) => data[searchItem].includes(keyword))
+                  .length !== 0 ? (
                 <AllList
                     allMapData={allMapData.filter((data) =>
-                        data.respondent_name.includes(keyword)
+                        data[searchItem].includes(keyword)
                     )}
                     dbMessages={dbMessages}
                 />
@@ -53,10 +62,18 @@ const All = ({ allMapData, dbMessages, saveDisplayMapIcons }) => {
 };
 
 const styles = {
+    searchContainer: css`
+        display: flex;
+    `,
+    buttons: css`
+        width: 40%;
+        margin-top: 5px;
+        margin-right: 2%;
+    `,
     textField: css`
-        justify-content: center;
-        width: 90%;
-        margin: 5px 5% 0;
+        justify-content: left;
+        width: 70%;
+        margin: 5px 2% 0;
     `,
     message: css`
         text-align: center;

--- a/src/features/SideMenu/components/All/AllList.jsx
+++ b/src/features/SideMenu/components/All/AllList.jsx
@@ -23,7 +23,7 @@ const AllList = ({allMapData, dbMessages }) => {
                 }}
             >
                 {allMapData.map((data) => (
-                    data.id ? (
+                    data.complete ? (
                         <CompleteListItem
                             saveDisplayMapIcons={() =>
                                 saveDisplayMapIcons(

--- a/src/features/SideMenu/components/Complete.jsx
+++ b/src/features/SideMenu/components/Complete.jsx
@@ -5,6 +5,7 @@ import { css } from "@emotion/react";
 import { TextField } from "@mui/material";
 
 import CompleteList from "./Complete/CompleteList";
+import TitleRow from "../TitleRow";
 
 const Incomplete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
@@ -32,6 +33,7 @@ const Incomplete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
                 }}
                 css={styles.textField}
             />
+            <TitleRow />
             {archivedMapData.length === 0 ? (
                 <div css={styles.message}>完了のデータがありません</div>
             ) : archivedMapData.filter((data) =>

--- a/src/features/SideMenu/components/Complete.jsx
+++ b/src/features/SideMenu/components/Complete.jsx
@@ -14,7 +14,7 @@ const Complete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
     const [searchItem, setSearchItem] = useState("respondent_name");
     const [sortItem, setSortItem] = useState("id");
-    const [isAsc, setIsAsc] = useState(false);
+    const [isAsc, setIsAsc] = useState(true);
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(

--- a/src/features/SideMenu/components/Complete.jsx
+++ b/src/features/SideMenu/components/Complete.jsx
@@ -6,13 +6,18 @@ import { TextField } from "@mui/material";
 
 import CompleteList from "./Complete/CompleteList";
 import TitleRow from "../TitleRow";
+import SelectSearchItem from "./SearchMenu/SelectSearchItem";
+import SelectSortItem from "./SearchMenu/SelectSortItem";
 
-const Incomplete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
+const Complete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
+    const [searchItem, setSearchItem] = useState("respondent_name");
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(
-            archivedMapData.filter((data) => data.respondent_name.includes(newKeyword))
+            archivedMapData.filter((data) =>
+                data[searchItem].includes(newKeyword)
+            )
         );
     };
 
@@ -24,24 +29,31 @@ const Incomplete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
 
     return (
         <>
-            <TextField
-                id="field"
-                variant="outlined"
-                label="検索"
-                onChange={(e) => {
-                    handleChange(e);
-                }}
-                css={styles.textField}
-            />
+            <div css={styles.searchContainer}>
+                <TextField
+                    id="field"
+                    variant="outlined"
+                    label="検索"
+                    onChange={(e) => {
+                        handleChange(e);
+                    }}
+                    css={styles.textField}
+                />
+                <div css={styles.buttons}>
+                    <SelectSearchItem setSearchItem={setSearchItem} />
+                    {/* TODO: 並び替え機能 */}
+                    <SelectSortItem />
+                </div>
+            </div>
             <TitleRow />
             {archivedMapData.length === 0 ? (
                 <div css={styles.message}>完了のデータがありません</div>
             ) : archivedMapData.filter((data) =>
-                data.respondent_name.includes(keyword)
-            ).length !== 0 ? (
+                  data[searchItem].includes(keyword)
+              ).length !== 0 ? (
                 <CompleteList
                     archivedMapData={archivedMapData.filter((data) =>
-                        data.respondent_name.includes(keyword)
+                        data[searchItem].includes(keyword)
                     )}
                     dbMessages={dbMessages}
                 />
@@ -53,10 +65,18 @@ const Incomplete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
 };
 
 const styles = {
+    searchContainer: css`
+        display: flex;
+    `,
+    buttons: css`
+        width: 40%;
+        margin-top: 5px;
+        margin-right: 2%;
+    `,
     textField: css`
-        justify-content: center;
-        width: 90%;
-        margin: 5px 5% 0;
+        justify-content: left;
+        width: 70%;
+        margin: 5px 2% 0;
     `,
     message: css`
         text-align: center;
@@ -64,4 +84,4 @@ const styles = {
     `,
 };
 
-export default Incomplete;
+export default Complete;

--- a/src/features/SideMenu/components/Complete.jsx
+++ b/src/features/SideMenu/components/Complete.jsx
@@ -12,6 +12,8 @@ import SelectSortItem from "./SearchMenu/SelectSortItem";
 const Complete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
     const [searchItem, setSearchItem] = useState("respondent_name");
+    const [sortItem, setSortItem] = useState("id");
+    const [isAsc, setIsAsc] = useState(false);
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(
@@ -41,20 +43,33 @@ const Complete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
                 />
                 <div css={styles.buttons}>
                     <SelectSearchItem setSearchItem={setSearchItem} />
-                    {/* TODO: 並び替え機能 */}
-                    <SelectSortItem />
+                    <SelectSortItem
+                        setSortItem={setSortItem}
+                        isAsc={isAsc}
+                        setIsAsc={setIsAsc}
+                    />
                 </div>
             </div>
-            <TitleRow />
+            <TitleRow isAsc={isAsc} setIsAsc={setIsAsc} />
             {archivedMapData.length === 0 ? (
                 <div css={styles.message}>完了のデータがありません</div>
             ) : archivedMapData.filter((data) =>
                   data[searchItem].includes(keyword)
               ).length !== 0 ? (
                 <CompleteList
-                    archivedMapData={archivedMapData.filter((data) =>
-                        data[searchItem].includes(keyword)
-                    )}
+                    archivedMapData={archivedMapData
+                        .filter((data) => data[searchItem].includes(keyword))
+                        .sort((a, b) =>
+                            sortItem === "scheduled" || "timestamp"
+                                ? isAsc
+                                    ? new Date(a[sortItem]) -
+                                      new Date(b[sortItem])
+                                    : new Date(b[sortItem]) -
+                                      new Date(a[sortItem])
+                                : isAsc
+                                ? a[sortItem] - b[sortItem]
+                                : b[sortItem] - a[sortItem]
+                        )}
                     dbMessages={dbMessages}
                 />
             ) : (

--- a/src/features/SideMenu/components/Complete.jsx
+++ b/src/features/SideMenu/components/Complete.jsx
@@ -6,11 +6,18 @@ import { TextField } from "@mui/material";
 
 import CompleteList from "./Complete/CompleteList";
 
-const Incomplete = ({ archivedMapData, dbMessages }) => {
+const Incomplete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
+
+    const changeMapIcons = (newKeyword) => {
+        saveDisplayMapIcons(
+            archivedMapData.filter((data) => data.respondent_name.includes(newKeyword))
+        );
+    };
 
     const handleChange = (e) => {
         const newKeyword = e.target.value;
+        changeMapIcons(newKeyword);
         setKeyword(newKeyword);
     };
 
@@ -28,8 +35,8 @@ const Incomplete = ({ archivedMapData, dbMessages }) => {
             {archivedMapData.length === 0 ? (
                 <div css={styles.message}>完了のデータがありません</div>
             ) : archivedMapData.filter((data) =>
-                  data.respondent_name.includes(keyword)
-              ).length !== 0 ? (
+                data.respondent_name.includes(keyword)
+            ).length !== 0 ? (
                 <CompleteList
                     archivedMapData={archivedMapData.filter((data) =>
                         data.respondent_name.includes(keyword)

--- a/src/features/SideMenu/components/Complete.jsx
+++ b/src/features/SideMenu/components/Complete.jsx
@@ -8,6 +8,7 @@ import CompleteList from "./Complete/CompleteList";
 import TitleRow from "../TitleRow";
 import SelectSearchItem from "./SearchMenu/SelectSearchItem";
 import SelectSortItem from "./SearchMenu/SelectSortItem";
+import ReverseListButton from "components/Button/ReverseListButton";
 
 const Complete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
@@ -50,7 +51,15 @@ const Complete = ({ archivedMapData, dbMessages, saveDisplayMapIcons }) => {
                     />
                 </div>
             </div>
-            <TitleRow isAsc={isAsc} setIsAsc={setIsAsc} />
+            <div css={styles.titleRowContainer}>
+                <TitleRow />
+                <ReverseListButton
+                    isAsc={isAsc}
+                    setIsAsc={setIsAsc}
+                    css={styles.reverseListButton}
+                />
+            </div>
+
             {archivedMapData.length === 0 ? (
                 <div css={styles.message}>完了のデータがありません</div>
             ) : archivedMapData.filter((data) =>
@@ -87,6 +96,10 @@ const styles = {
         width: 40%;
         margin-top: 5px;
         margin-right: 2%;
+    `,
+    titleRowContainer: css`
+        display: flex;
+        border-bottom: 1px solid #cecece;
     `,
     textField: css`
         justify-content: left;

--- a/src/features/SideMenu/components/Incomplete.jsx
+++ b/src/features/SideMenu/components/Incomplete.jsx
@@ -14,7 +14,7 @@ const Incomplete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
     const [searchItem, setSearchItem] = useState("respondent_name");
     const [sortItem, setSortItem] = useState("id");
-    const [isAsc, setIsAsc] = useState(false);
+    const [isAsc, setIsAsc] = useState(true);
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(

--- a/src/features/SideMenu/components/Incomplete.jsx
+++ b/src/features/SideMenu/components/Incomplete.jsx
@@ -6,13 +6,16 @@ import { TextField } from "@mui/material";
 
 import MapList from "./Incomplete/MapList";
 import TitleRow from "../TitleRow";
+import SelectSearchItem from "./SearchMenu/SelectSearchItem";
+import SelectSortItem from "./SearchMenu/SelectSortItem";
 
-const Complete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
+const Incomplete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
+    const [searchItem, setSearchItem] = useState("respondent_name");
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(
-            mapData.filter((data) => data.respondent_name.includes(newKeyword))
+            mapData.filter((data) => data[searchItem].includes(newKeyword))
         );
     };
 
@@ -24,23 +27,30 @@ const Complete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
 
     return (
         <>
-            <TextField
-                id="field"
-                variant="outlined"
-                label="検索"
-                onChange={(e) => {
-                    handleChange(e);
-                }}
-                css={styles.textField}
-            />
+            <div css={styles.searchContainer}>
+                <TextField
+                    id="field"
+                    variant="outlined"
+                    label="検索"
+                    onChange={(e) => {
+                        handleChange(e);
+                    }}
+                    css={styles.textField}
+                />
+                <div css={styles.buttons}>
+                    <SelectSearchItem setSearchItem={setSearchItem}/>
+                    {/* TODO: 並び替え機能 */}
+                    <SelectSortItem />
+                </div>
+            </div>
             <TitleRow />
             {mapData.length === 0 ? (
                 <div css={styles.message}>未完了のデータがありません</div>
-            ) : mapData.filter((data) => data.respondent_name.includes(keyword))
+            ) : mapData.filter((data) => data[searchItem].includes(keyword))
                   .length !== 0 ? (
                 <MapList
                     mapData={mapData.filter((data) =>
-                        data.respondent_name.includes(keyword)
+                        data[searchItem].includes(keyword)
                     )}
                     dbMessages={dbMessages}
                 />
@@ -52,10 +62,18 @@ const Complete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
 };
 
 const styles = {
+    searchContainer: css`
+        display: flex;
+    `,
+    buttons: css`
+        width: 40%;
+        margin-top: 5px;
+        margin-right: 2%;
+    `,
     textField: css`
-        justify-content: center;
-        width: 90%;
-        margin: 5px 5% 0;
+        justify-content: left;
+        width: 70%;
+        margin: 5px 2% 0;
     `,
     message: css`
         text-align: center;
@@ -63,4 +81,4 @@ const styles = {
     `,
 };
 
-export default Complete;
+export default Incomplete;

--- a/src/features/SideMenu/components/Incomplete.jsx
+++ b/src/features/SideMenu/components/Incomplete.jsx
@@ -12,6 +12,8 @@ import SelectSortItem from "./SearchMenu/SelectSortItem";
 const Incomplete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
     const [searchItem, setSearchItem] = useState("respondent_name");
+    const [sortItem, setSortItem] = useState("id");
+    const [isAsc, setIsAsc] = useState(false);
 
     const changeMapIcons = (newKeyword) => {
         saveDisplayMapIcons(
@@ -38,20 +40,33 @@ const Incomplete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
                     css={styles.textField}
                 />
                 <div css={styles.buttons}>
-                    <SelectSearchItem setSearchItem={setSearchItem}/>
-                    {/* TODO: 並び替え機能 */}
-                    <SelectSortItem />
+                    <SelectSearchItem setSearchItem={setSearchItem} />
+                    <SelectSortItem
+                        setSortItem={setSortItem}
+                        isAsc={isAsc}
+                        setIsAsc={setIsAsc}
+                    />
                 </div>
             </div>
-            <TitleRow />
+            <TitleRow isAsc={isAsc} setIsAsc={setIsAsc} />
             {mapData.length === 0 ? (
                 <div css={styles.message}>未完了のデータがありません</div>
             ) : mapData.filter((data) => data[searchItem].includes(keyword))
                   .length !== 0 ? (
                 <MapList
-                    mapData={mapData.filter((data) =>
-                        data[searchItem].includes(keyword)
-                    )}
+                    mapData={mapData
+                        .filter((data) => data[searchItem].includes(keyword))
+                        .sort((a, b) =>
+                            sortItem === "scheduled" || "timestamp"
+                                ? isAsc
+                                    ? new Date(a[sortItem]) -
+                                      new Date(b[sortItem])
+                                    : new Date(b[sortItem]) -
+                                      new Date(a[sortItem])
+                                : isAsc
+                                ? a[sortItem] - b[sortItem]
+                                : b[sortItem] - a[sortItem]
+                        )}
                     dbMessages={dbMessages}
                 />
             ) : (

--- a/src/features/SideMenu/components/Incomplete.jsx
+++ b/src/features/SideMenu/components/Incomplete.jsx
@@ -5,6 +5,7 @@ import { css } from "@emotion/react";
 import { TextField } from "@mui/material";
 
 import MapList from "./Incomplete/MapList";
+import TitleRow from "../TitleRow";
 
 const Complete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
@@ -32,6 +33,7 @@ const Complete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
                 }}
                 css={styles.textField}
             />
+            <TitleRow />
             {mapData.length === 0 ? (
                 <div css={styles.message}>未完了のデータがありません</div>
             ) : mapData.filter((data) => data.respondent_name.includes(keyword))

--- a/src/features/SideMenu/components/Incomplete.jsx
+++ b/src/features/SideMenu/components/Incomplete.jsx
@@ -8,6 +8,7 @@ import MapList from "./Incomplete/MapList";
 import TitleRow from "../TitleRow";
 import SelectSearchItem from "./SearchMenu/SelectSearchItem";
 import SelectSortItem from "./SearchMenu/SelectSortItem";
+import ReverseListButton from "components/Button/ReverseListButton";
 
 const Incomplete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
@@ -48,7 +49,15 @@ const Incomplete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
                     />
                 </div>
             </div>
-            <TitleRow isAsc={isAsc} setIsAsc={setIsAsc} />
+            <div css={styles.titleRowContainer}>
+                <TitleRow />
+                <ReverseListButton
+                    isAsc={isAsc}
+                    setIsAsc={setIsAsc}
+                    css={styles.reverseListButton}
+                />
+            </div>
+
             {mapData.length === 0 ? (
                 <div css={styles.message}>未完了のデータがありません</div>
             ) : mapData.filter((data) => data[searchItem].includes(keyword))
@@ -84,6 +93,10 @@ const styles = {
         width: 40%;
         margin-top: 5px;
         margin-right: 2%;
+    `,
+    titleRowContainer: css`
+        display: flex;
+        border-bottom: 1px solid #cecece;
     `,
     textField: css`
         justify-content: left;

--- a/src/features/SideMenu/components/Incomplete.jsx
+++ b/src/features/SideMenu/components/Incomplete.jsx
@@ -6,11 +6,18 @@ import { TextField } from "@mui/material";
 
 import MapList from "./Incomplete/MapList";
 
-const Complete = ({ mapData, dbMessages }) => {
+const Complete = ({ mapData, dbMessages, saveDisplayMapIcons }) => {
     const [keyword, setKeyword] = useState("");
+
+    const changeMapIcons = (newKeyword) => {
+        saveDisplayMapIcons(
+            mapData.filter((data) => data.respondent_name.includes(newKeyword))
+        );
+    };
 
     const handleChange = (e) => {
         const newKeyword = e.target.value;
+        changeMapIcons(newKeyword);
         setKeyword(newKeyword);
     };
 

--- a/src/features/SideMenu/components/MenuBar.jsx
+++ b/src/features/SideMenu/components/MenuBar.jsx
@@ -22,7 +22,6 @@ const MenuBar = ({ menu, selectMenu }) => {
                 <Tab icon={<ViewListIcon />} label="未完了" />
                 <Tab icon={<ArchiveIcon />} label="完了" />
                 <Tab icon={<AutoAwesomeMotionTwoToneIcon />} label="全件表示" />
-                <Tab icon={<SearchIcon />} label="検索" />
             </Tabs>
         </>
     );

--- a/src/features/SideMenu/components/SearchMenu/SearchMenu.jsx
+++ b/src/features/SideMenu/components/SearchMenu/SearchMenu.jsx
@@ -1,64 +1,64 @@
-import { useState } from "react";
+// import { useState } from "react";
 
-import { Button } from "@mui/material";
+// import { Button } from "@mui/material";
 
-import MapList from "../Incomplete/MapList";
-import SelectForm from "./SelectForm";
-import SearchMenuBar from "./SearchMenuBar";
-import { useEffect } from "react";
+// import MapList from "../Incomplete/MapList";
+// import SelectForm from "./SelectForm";
+// import SearchMenuBar from "./SearchMenuBar";
+// import { useEffect } from "react";
 
-import { TextField } from "@mui/material";
-// import { styles } from "@material-ui/pickers/views/Calendar/Calendar";
+// import { TextField } from "@mui/material";
+// // import { styles } from "@material-ui/pickers/views/Calendar/Calendar";
 
-import { css } from "@emotion/react";
+// import { css } from "@emotion/react";
 
-const SearchMenu = ({ mapData, saveDisplayMapIcons, dbMessages }) => {
-    const [keyword, setKeyword] = useState("");
-    const [filteredData, setFilteredData] = useState(mapData);
+// const SearchMenu = ({ mapData, saveDisplayMapIcons, dbMessages }) => {
+//     const [keyword, setKeyword] = useState("");
+//     const [filteredData, setFilteredData] = useState(mapData);
 
-    const handleChange = (e) => {
-        const newKeyword = e.target.value;
-        setKeyword(newKeyword);
-    };
+//     const handleChange = (e) => {
+//         const newKeyword = e.target.value;
+//         setKeyword(newKeyword);
+//     };
 
-    useEffect(() => {
-        console.log("変更 : " + keyword);
+//     useEffect(() => {
+//         console.log("変更 : " + keyword);
 
-        const searchKeyword = keyword
-            .trim()
-            .toLowerCase()
-            .match(/[^\s]+/g);
+//         const searchKeyword = keyword
+//             .trim()
+//             .toLowerCase()
+//             .match(/[^\s]+/g);
 
-        if (keyword === "" || searchKeyword === null) {
-            setFilteredData(mapData);
-            return;
-        }
+//         if (keyword === "" || searchKeyword === null) {
+//             setFilteredData(mapData);
+//             return;
+//         }
 
-        const result = mapData.filter((data) =>
-            searchKeyword.every(
-                (kw) => data.respondent_name.toLowerCase().indexOf(kw) !== -1
-            )
-        );
-        setFilteredData(result);
-    }, [keyword]);
+//         const result = mapData.filter((data) =>
+//             searchKeyword.every(
+//                 (kw) => data.respondent_name.toLowerCase().indexOf(kw) !== -1
+//             )
+//         );
+//         setFilteredData(result);
+//     }, [keyword]);
 
-    return (
-        <>
-            <h2>検索機能は未実装</h2>
-        </>
-    );
-};
+//     return (
+//         <>
+//             <h2>検索機能は未実装</h2>
+//         </>
+//     );
+// };
 
-const styles = {
-    textField: css`
-        justify-content: center;
-        width: 90%;
-        margin: 5px 5% 0;
-    `,
-    message: css`
-        text-align: center;
-        margin-top: 10px;
-    `
-};
+// const styles = {
+//     textField: css`
+//         justify-content: center;
+//         width: 90%;
+//         margin: 5px 5% 0;
+//     `,
+//     message: css`
+//         text-align: center;
+//         margin-top: 10px;
+//     `
+// };
 
-export default SearchMenu;
+// export default SearchMenu;

--- a/src/features/SideMenu/components/SearchMenu/SearchMenuBar.jsx
+++ b/src/features/SideMenu/components/SearchMenu/SearchMenuBar.jsx
@@ -1,28 +1,28 @@
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+// import Tabs from '@mui/material/Tabs';
+// import Tab from '@mui/material/Tab';
 
-const SearchMenuBar=({
-    menu,
-    selectMenu
-})=>{
-    const handleChange = (_, newValue) => {
-        selectMenu(newValue);
-    };
+// const SearchMenuBar=({
+//     menu,
+//     selectMenu
+// })=>{
+//     const handleChange = (_, newValue) => {
+//         selectMenu(newValue);
+//     };
 
-    return (
-    <>
-        <Tabs
-            value={menu}
-            onChange={handleChange}
-            aria-label="icon label tabs example"
-            centered
-            style={{margin:"5px"}}
-        >
-            <Tab  label="検索" />
-            <Tab label="検索結果" />
-        </Tabs>
-    </>
-    )
-}
+//     return (
+//     <>
+//         <Tabs
+//             value={menu}
+//             onChange={handleChange}
+//             aria-label="icon label tabs example"
+//             centered
+//             style={{margin:"5px"}}
+//         >
+//             <Tab  label="検索" />
+//             <Tab label="検索結果" />
+//         </Tabs>
+//     </>
+//     )
+// }
 
-export default SearchMenuBar;
+// export default SearchMenuBar;

--- a/src/features/SideMenu/components/SearchMenu/SelectForm.jsx
+++ b/src/features/SideMenu/components/SearchMenu/SelectForm.jsx
@@ -1,49 +1,49 @@
-import {useState} from 'react';
+// import {useState} from 'react';
 
-import OutlinedInput from '@mui/material/OutlinedInput';
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
+// import OutlinedInput from '@mui/material/OutlinedInput';
+// import InputLabel from '@mui/material/InputLabel';
+// import MenuItem from '@mui/material/MenuItem';
+// import Select from '@mui/material/Select';
 
 
-const SelectForm=({
-    selectLavel="",
-    select,
-    changeSelectValue,
-    defaultValue
-})=>{
+// const SelectForm=({
+//     selectLavel="",
+//     select,
+//     changeSelectValue,
+//     defaultValue
+// })=>{
 
-    const [selectValue,setSelectValue]=useState(defaultValue===""?"指定なし":defaultValue);
-    const handleChange = (event) => {
-        setSelectValue(event.target.value);
-        const data=event.target.value;
-        if(data==="指定なし"){
-            changeSelectValue("");
-        }else{
-            changeSelectValue(data);
-        }
-    };
-    return (
-    <div style={{height:'100px',textAlign:'center'}}>
-        <InputLabel>{selectLavel}</InputLabel>
-        <Select
-            value={selectValue}
-            onChange={handleChange}
-            select={<OutlinedInput label={selectValue} />}
-            style={{height:'60px',width:'80%'}}
+//     const [selectValue,setSelectValue]=useState(defaultValue===""?"指定なし":defaultValue);
+//     const handleChange = (event) => {
+//         setSelectValue(event.target.value);
+//         const data=event.target.value;
+//         if(data==="指定なし"){
+//             changeSelectValue("");
+//         }else{
+//             changeSelectValue(data);
+//         }
+//     };
+//     return (
+//     <div style={{height:'100px',textAlign:'center'}}>
+//         <InputLabel>{selectLavel}</InputLabel>
+//         <Select
+//             value={selectValue}
+//             onChange={handleChange}
+//             select={<OutlinedInput label={selectValue} />}
+//             style={{height:'60px',width:'80%'}}
 
-        >
-        {select.map((value) => (
-            <MenuItem
-                key={value}
-                value={value}
-            >
-                {value}
-            </MenuItem>
-        ))}
-        </Select>
-    </div>
-    )
-}
+//         >
+//         {select.map((value) => (
+//             <MenuItem
+//                 key={value}
+//                 value={value}
+//             >
+//                 {value}
+//             </MenuItem>
+//         ))}
+//         </Select>
+//     </div>
+//     )
+// }
 
-export default SelectForm;
+// export default SelectForm;

--- a/src/features/SideMenu/components/SearchMenu/SelectSearchItem.jsx
+++ b/src/features/SideMenu/components/SearchMenu/SelectSearchItem.jsx
@@ -1,14 +1,13 @@
 import React, { useState } from "react";
-import useDialog from "hooks/useDialog";
 
-import { Button, Menu, MenuItem, ListItemIcon } from "@mui/material";
+import { Button, Menu, MenuItem, ListItemIcon, Tooltip } from "@mui/material";
 import ManageSearchIcon from "@mui/icons-material/ManageSearch";
 import { css } from "@emotion/react";
 
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import RadioButtonCheckedIcon from "@mui/icons-material/RadioButtonChecked";
 
-const SelectSearchItem = ( {setSearchItem} ) => {
+const SelectSearchItem = ({ setSearchItem }) => {
     const defaultName = { displayName: "選ぶ" };
     const searchItems = [
         { id: 0, itemName: "respondent_name", displayName: "情報提供者" },
@@ -36,19 +35,24 @@ const SelectSearchItem = ( {setSearchItem} ) => {
 
     return (
         <>
-            <Button
-                startIcon={<ManageSearchIcon />}
-                variant="outlined"
-                css={styles.button}
-                onClick={handleOpen}
-            >
-                <span css={styles.selectedItem}>
-                    {selectedItem?.displayName}
-                </span>
-            </Button>
+            <Tooltip title="検索する項目を選択" placement="right">
+                <Button
+                    startIcon={<ManageSearchIcon />}
+                    variant="outlined"
+                    css={styles.button}
+                    onClick={handleOpen}
+                >
+                    <span css={styles.selectedItem}>
+                        {selectedItem?.displayName}
+                    </span>
+                </Button>
+            </Tooltip>
             <Menu open={open} onClose={handleClose} anchorEl={anchorEl}>
                 {searchItems.map((item) => (
-                    <MenuItem onClick={() => handleClick(item.id)} key={item.id}>
+                    <MenuItem
+                        onClick={() => handleClick(item.id)}
+                        key={item.id}
+                    >
                         <ListItemIcon>
                             {item.id === selectedItem?.id ? (
                                 <RadioButtonCheckedIcon />

--- a/src/features/SideMenu/components/SearchMenu/SelectSearchItem.jsx
+++ b/src/features/SideMenu/components/SearchMenu/SelectSearchItem.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import useDialog from "hooks/useDialog";
+
+import { Button, Menu, MenuItem, ListItemIcon } from "@mui/material";
+import ManageSearchIcon from "@mui/icons-material/ManageSearch";
+import { css } from "@emotion/react";
+
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
+import RadioButtonCheckedIcon from "@mui/icons-material/RadioButtonChecked";
+
+const SelectSearchItem = ( {setSearchItem} ) => {
+    const defaultName = { displayName: "選ぶ" };
+    const searchItems = [
+        { id: 0, itemName: "respondent_name", displayName: "情報提供者" },
+        { id: 1, itemName: "manager", displayName: "担当者" },
+        { id: 2, itemName: "address", displayName: "住所" },
+    ];
+
+    const [anchorEl, setAnchorEl] = useState(null);
+    const [selectedItem, setSelectedItem] = useState(defaultName);
+
+    const open = Boolean(anchorEl);
+    const handleOpen = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    const handleClick = (id) => {
+        const newItem = searchItems.find((item) => item.id === id);
+        setSelectedItem(newItem);
+        setSearchItem(newItem.itemName);
+        handleClose();
+    };
+
+    return (
+        <>
+            <Button
+                startIcon={<ManageSearchIcon />}
+                variant="outlined"
+                css={styles.button}
+                onClick={handleOpen}
+            >
+                <span css={styles.selectedItem}>
+                    {selectedItem?.displayName}
+                </span>
+            </Button>
+            <Menu open={open} onClose={handleClose} anchorEl={anchorEl}>
+                {searchItems.map((item) => (
+                    <MenuItem onClick={() => handleClick(item.id)} key={item.id}>
+                        <ListItemIcon>
+                            {item.id === selectedItem?.id ? (
+                                <RadioButtonCheckedIcon />
+                            ) : (
+                                <RadioButtonUncheckedIcon />
+                            )}
+                        </ListItemIcon>
+                        {item.displayName}
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
+    );
+};
+
+const styles = {
+    button: css`
+        width: 100%;
+        height: 40%;
+    `,
+    selectedItem: css`
+        font-size: 5px;
+    `,
+    dialogContainer: css`
+        width: 10%;
+        height: 50%;
+    `,
+};
+
+export default SelectSearchItem;

--- a/src/features/SideMenu/components/SearchMenu/SelectSortItem.jsx
+++ b/src/features/SideMenu/components/SearchMenu/SelectSortItem.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { Button } from "@mui/material";
+import SortIcon from "@mui/icons-material/Sort";
+import { css } from "@emotion/react";
+
+const SelectSortItem = () => {
+    return (
+        <>
+            <Button
+                startIcon={<SortIcon />}
+                variant="outlined"
+                css={styles.button}
+            >
+                <span css={styles.selectedItem}>項目名あ</span>
+            </Button>
+        </>
+    );
+};
+
+const styles = {
+    button: css`
+        height: 40%;
+        width: 100%;
+        margin-top: 2.5%;
+    `,
+    selectedItem: css`
+        font-size: 5px;
+    `,
+};
+
+export default SelectSortItem;

--- a/src/features/SideMenu/components/SearchMenu/SelectSortItem.jsx
+++ b/src/features/SideMenu/components/SearchMenu/SelectSortItem.jsx
@@ -1,19 +1,71 @@
-import React from "react";
+import React, { useState } from "react";
 
-import { Button } from "@mui/material";
+import { Button, ListItemIcon, Menu, MenuItem, Tooltip } from "@mui/material";
 import SortIcon from "@mui/icons-material/Sort";
 import { css } from "@emotion/react";
 
-const SelectSortItem = () => {
+import RadioButtonCheckedIcon from "@mui/icons-material/RadioButtonChecked";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
+
+const SelectSortItem = ({ setSortItem }) => {
+    const defaultItem = { displayName: "選ぶ" };
+    const sortItems = [
+        { id: 0, itemName: "timestamp", displayName: "受付日" },
+        { id: 1, itemName: "progress", displayName: "進捗度" },
+        { id: 2, itemName: "id", displayName: "苦情番号" },
+        { id: 3, itemName: "scheduled", displayName: "予定日" },
+    ];
+
+    const [selectedItem, setSelectedItem] = useState(defaultItem);
+    const [anchorEl, setAnchorEl] = useState(null);
+    const open = Boolean(anchorEl);
+
+    const handleOpen = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    const handleClick = (id) => {
+        const newItem = sortItems.find((item) => item.id === id);
+        setSelectedItem(newItem);
+        setSortItem(newItem.itemName);
+        handleClose();
+    };
+
     return (
         <>
+        <Tooltip title="ソートする項目を選択" placement="right">
             <Button
                 startIcon={<SortIcon />}
                 variant="outlined"
                 css={styles.button}
+                onClick={handleOpen}
             >
-                <span css={styles.selectedItem}>項目名あ</span>
+                <span css={styles.selectedItem}>
+                    {selectedItem.displayName}
+                </span>
             </Button>
+            </Tooltip>
+            <Menu open={open} onClose={handleClose} anchorEl={anchorEl}>
+                {sortItems.map((item) => (
+                    <MenuItem
+                        onClick={() => handleClick(item.id)}
+                        key={item.id}
+                    >
+                        <ListItemIcon>
+                            {item.id === selectedItem?.id ? (
+                                <RadioButtonCheckedIcon />
+                            ) : (
+                                <RadioButtonUncheckedIcon />
+                            )}
+                        </ListItemIcon>
+                        {item.displayName}
+                    </MenuItem>
+                ))}
+            </Menu>
         </>
     );
 };
@@ -26,6 +78,10 @@ const styles = {
     `,
     selectedItem: css`
         font-size: 5px;
+    `,
+    dialogContainer: css`
+        width: 10%;
+        height: 50%;
     `,
 };
 

--- a/src/page/Home.jsx
+++ b/src/page/Home.jsx
@@ -19,7 +19,6 @@ export const RevertArchive = createContext();
 export const ImageUrl = createContext();
 export const ChangeManager = createContext();
 
-//URLさえわかれば、だれでも情報の書き換えができてしまうのでログイン機能の実装が必要
 const Home = () => {
     //プロップスリレーが生じていたのでuseContextで実装した
 
@@ -112,7 +111,7 @@ const Home = () => {
             setMapData(json.filter((data) => data.complete !== true));
             setArchivedMapData(json.filter((data) => data.complete === true));
             setLoad(false);
-            setDisplayMapIcons(json);
+            setDisplayMapIcons(json.filter((data) => data.complete !== true));
             setAllData(json);
         })();
     }, []);


### PR DESCRIPTION
・キーワード検索が、Mapのピンに反映されない　➡︎　useEffectでsetDisplayMapIconsを走らせる OK
・検索と同時にMapのピンも減らす処理 OK
・SideMenuのリストの上に、項目名を表示する OK
（苦情番号　苦情箇所名　情報提供者名）
・ダミーデータの変更（より現実味があるデータにする） OK
・検索機能　＝＞　一つ内側に入れて検索項目を担当者名・住所・情報提供者を選択できるボタンを検索キーワード欄の隣に追加する OK
・並べ替え機能　＝＞　検索ボタンの下にボタンを追加して、受付日・進捗度・苦情番号・予定日で並べ替えできるようにしてみる OK
・担当者を設定できるところが欲しいかも　→　カッシーが実装

アプリ上でピンの位置を変更できる機能はあった方がいいかも OK
未実施と実施済を区別したい OK
